### PR TITLE
Introduce leaf certificate aliasing target

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,22 @@ cd [path to tls-gen repository]/basic
 # pass a private key password using the PASSWORD variable if needed
 make
 
-## copy or move files to use hostname-neutral filenames,
+## copy or move files to use hostname-neutral filenames
+## such as client_certificate.pem and client_key.pem,
 ## this step is optional
-# cp result/client_$(hostname)_certificate.pem result/client_certificate.pem
-# cp result/client_$(hostname)_key.pem         result/client_key.pem
-# cp result/server_$(hostname)_certificate.pem result/server_certificate.pem
-# cp result/server_$(hostname)_key.pem         result/server_key.pem
+# make alias-leaf-artifacts
 
 # results will be under the ./result directory
 ls -lha ./result
 ```
 
 Generated CA certificate as well as client and server certificate and private keys will be
-under the `result` directory.
+under the `result` directory. Their names will include hostnames. To use
+"host-neutral" names such as `client_certificate.pem` and `client_key.pem`, use
+
+``` shell
+make alias-leaf-artifacts
+```
 
 It possible to use [ECC][ecc-intro] for leaf keys:
 

--- a/basic/profile.py
+++ b/basic/profile.py
@@ -80,12 +80,26 @@ def verify_pkcs12(opts):
 
 def info(opts):
     cn = opts.common_name
-    name = 'client_{}'.format(cn)
-    info.leaf_certificate_info(name)
+    client_name = 'client_{}'.format(cn)
+    info.leaf_certificate_info(client_name)
 
+    server_name = 'server_{}'.format(cn)
+    info.leaf_certificate_info(server_name)
+
+def alias_leaf_artifacts(opts):
     cn = opts.common_name
-    name = 'server_{}'.format(cn)
-    info.leaf_certificate_info(name)
+    client_name = 'client_{}'.format(cn)
+    server_name = 'server_{}'.format(cn)
+
+    print("Will copy certificate and key for {} to {}".format(client_name, paths.relative_path(*("result", "client_*.pem"))))
+    print("Will copy certificate and key for {} to {}".format(server_name, paths.relative_path(*("result", "server_*.pem"))))
+
+    gen.alias_file("client", client_name)
+    gen.alias_file("server", client_name)
+
+    print("Done! Find new copies under ./result!")
+
+
 
 commands = {"generate":        generate,
             "gen":             generate,
@@ -96,7 +110,8 @@ commands = {"generate":        generate,
             "regen":           regenerate,
             "verify":          verify,
             "verify-pkcs12":   verify_pkcs12,
-            "info":            info}
+            "info":            info,
+            "alias-leaf-artifacts": alias_leaf_artifacts}
 
 if __name__ == "__main__":
     sys.path.append("..")

--- a/common.mk
+++ b/common.mk
@@ -91,5 +91,8 @@ info:
 verify:
 	$(PYTHON) profile.py verify --common-name $(CN)
 
+alias-leaf-artifacts:
+	$(PYTHON) profile.py alias-leaf-artifacts
+
 help:
 	$(PYTHON) profile.py --help

--- a/separate_intermediates/profile.py
+++ b/separate_intermediates/profile.py
@@ -86,13 +86,18 @@ def info(opts):
     info.leaf_certificate_info("client")
     info.leaf_certificate_info("server")
 
+def alias_leaf_artifacts(opts):
+    print("This command is not supported by this profile")
+
+
 commands = {"generate":   generate,
             "gen":        generate,
             "clean":      clean,
             "regenerate": regenerate,
             "regen":      regenerate,
             "verify":     verify,
-            "info":       info}
+            "info":       info,
+            "alias-leaf-artifacts": alias_leaf_artifacts}
 
 if __name__ == "__main__":
     sys.path.append("..")

--- a/tls_gen/gen.py
+++ b/tls_gen/gen.py
@@ -59,6 +59,14 @@ def copy_leaf_certificate_and_key_pair(peer):
     copy_tuple_path((peer, "key.pem"),     (result_dir_name, "{}_key.pem".format(peer)))
     copy_tuple_path((peer, "keycert.p12"), (result_dir_name, "{}_key.p12".format(peer)))
 
+def alias_file(kind, peer):
+    """
+    Copies a leaf certificate to commonly used file names (e.g. client_certificate.pem)
+    under the results directory
+    """
+    copy_tuple_path((result_dir_name, "{}_certificate.pem".format(peer)), (result_dir_name, "{}_certificate.pem".format(kind)))
+    copy_tuple_path((result_dir_name, "{}_key.pem".format(peer)),         (result_dir_name, "{}_key.pem".format(kind)))
+
 def openssl_req(opts, *args, **kwargs):
     cnf_path = get_openssl_cnf_path(opts)
     print("=>\t[openssl_req]")

--- a/tls_gen/paths.py
+++ b/tls_gen/paths.py
@@ -25,7 +25,6 @@ def copy_tuple_path(from_tuple, to_tuple):
 
 def openssl_cnf_path():
     return relative_path("openssl.cnf")
-
 #
 # Root CA
 #

--- a/two_shared_intermediates/profile.py
+++ b/two_shared_intermediates/profile.py
@@ -81,13 +81,18 @@ def info(opts):
     info.leaf_certificate_info("client")
     info.leaf_certificate_info("server")
 
+def alias_leaf_artifacts(opts):
+    print("This command is not supported by this profile")
+
+
 commands = {"generate":   generate,
             "gen":        generate,
             "clean":      clean,
             "regenerate": regenerate,
             "regen":      regenerate,
             "verify":     verify,
-            "info":       info}
+            "info":       info,
+            "alias-leaf-artifacts": alias_leaf_artifacts}
 
 if __name__ == "__main__":
     sys.path.append("..")


### PR DESCRIPTION
As of #37, tls-gen's basic profile includes hostname
into certificate and private key file names. I miss the
simplicify of having results/client_certificate.pem,
results/client_key.pem and so on.

So let's introduce a target that would compute the paths
and do the copying so I don't have to.