### PR TITLE
gen-server should take alt name for server

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -74,7 +74,7 @@ gen-client:
 gen-server:
 	$(PYTHON) profile.py generate-server --password $(PASS) \
 	--common-name '$(CN)' \
-	--client-alt-name $(CLIENT_ALT_NAME) \
+	--server-alt-name $(SERVER_ALT_NAME) \
 	--days-of-validity $(DAYS_OF_VALIDITY) \
 	--key-bits $(NUMBER_OF_PRIVATE_KEY_BITS) $(ECC_FLAGS)
 


### PR DESCRIPTION
`make gen-server` should take alt name for server instead of client name.