### PR TITLE
add common-name parameter to alias-leaf-artifacts

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -93,7 +93,7 @@ verify:
 	$(PYTHON) profile.py verify --common-name '$(CN)'
 
 alias-leaf-artifacts:
-	$(PYTHON) profile.py alias-leaf-artifacts
+	$(PYTHON) profile.py alias-leaf-artifacts --common-name '$(CN)'
 
 help:
 	$(PYTHON) profile.py --help


### PR DESCRIPTION
If a custom common name is used, alias-leaf-artifacts will fail using the default common name.
Passing common name would be a better solution.